### PR TITLE
Edits to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # FabricTOC
 
-This repository is a working area for the Hyperledger Fabric Documentation Workgroup to develop the Table of Contents (TOC) for the Administration guide section of the Hyperledger Fabric documentation https://hyperledger-fabric.readthedocs.io/en/latest/.
+This repository is a working area for the Hyperledger Fabric Documentation Workgroup to develop the Table of Contents (TOC) for the Operations Guide section of the Hyperledger Fabric documentation https://hyperledger-fabric.readthedocs.io/en/latest/.
 
-It's purpose is to facilitate collaborative development of the  Administration Guide section of the documentation, such that it can be included in the Hyperledger Fabric documentation repository.
+Its purpose is to facilitate collaborative development of the Operations/Administration Guide section of the documentation, such that it can be included in the Hyperledger Fabric documentation repository.
 
-It uses markdown to help documentation developers easily edit and view their changes on their local machine, while maintaining source control through GitHub.
+It uses markdown to help documentation developers easily edit and view their changes on their local machine while maintaining source control through GitHub.
 
 We recommend using ATOM (https://atom.io/), or editors with similar previewing facilities, to help develop this content.
 


### PR DESCRIPTION
It's called "Operations Guide" in readthedocs, so I edited this doc to reflect that since we point to those docs. If we'd rather this be called "Administration Guide" we can have that discussion and work on it, but it should be called what it's called until then.  